### PR TITLE
Capitalize PropTypes in React.PropTypes

### DIFF
--- a/snippets/propTypes.sublime-snippet
+++ b/snippets/propTypes.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 propTypes: {
-  ${1}: React.propTypes.${2:string}
+  ${1}: React.PropTypes.${2:string}
 },
 ]]></content>
     <tabTrigger>pt</tabTrigger>


### PR DESCRIPTION
the `propTypes` entry is correct, but the p in `React.propTypes` should be capitalized ([link](http://facebook.github.io/react/docs/reusable-components.html)). Thanks for the great snippets!
