### PR TITLE
Tabs instead of spaces in snippets

### DIFF
--- a/snippets/componentDidMount.sublime-snippet
+++ b/snippets/componentDidMount.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 componentDidMount: function() {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>cdm</tabTrigger>

--- a/snippets/componentDidUpdate.sublime-snippet
+++ b/snippets/componentDidUpdate.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 componentDidUpdate: function(prevProps, prevState) {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>cdup</tabTrigger>

--- a/snippets/componentWillMount.sublime-snippet
+++ b/snippets/componentWillMount.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 componentWillMount: function() {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>cwm</tabTrigger>

--- a/snippets/componentWillReceiveProps.sublime-snippet
+++ b/snippets/componentWillReceiveProps.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 componentWillReceiveProps: function(nextProps) {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>cwr</tabTrigger>

--- a/snippets/componentWillUnmount.sublime-snippet
+++ b/snippets/componentWillUnmount.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 componentWillUnmount: function() {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>cwun</tabTrigger>

--- a/snippets/componentWillUpdate.sublime-snippet
+++ b/snippets/componentWillUpdate.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 componentWillUpdate: function(nextProps, nextState) {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>cwu</tabTrigger>

--- a/snippets/getDefaultProps.sublime-snippet
+++ b/snippets/getDefaultProps.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
     <content><![CDATA[
 getDefaultProps: function() {
-  return {
-    ${1}
-  };
+	return {
+		${1}
+	};
 },
 ]]></content>
     <tabTrigger>gdp</tabTrigger>

--- a/snippets/getInitialState.sublime-snippet
+++ b/snippets/getInitialState.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
     <content><![CDATA[
 getInitialState: function() {
-  return {
-    ${1}: ${2}
-  };
+	return {
+		${1}: ${2}
+	};
 },
 ]]></content>
     <tabTrigger>gis</tabTrigger>

--- a/snippets/propTypes.sublime-snippet
+++ b/snippets/propTypes.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 propTypes: {
-  ${1}: React.PropTypes.${2:string}
+	${1}: React.PropTypes.${2:string}
 },
 ]]></content>
     <tabTrigger>pt</tabTrigger>

--- a/snippets/react_component.sublime-snippet
+++ b/snippets/react_component.sublime-snippet
@@ -7,11 +7,11 @@ var React = require('React');
 
 var ${1} = React.createClass({
 
-  render: function() {
-    return (
-      ${0:<div />}
-    );
-  }
+	render: function() {
+		return (
+			${0:<div />}
+		);
+	}
 
 });
 

--- a/snippets/render.sublime-snippet
+++ b/snippets/render.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
     <content><![CDATA[
 render: function() {
-  return (
-    ${1:<div />}
-  );
+	return (
+		${1:<div />}
+	);
 }
 ]]></content>
     <tabTrigger>ren</tabTrigger>

--- a/snippets/setState.sublime-snippet
+++ b/snippets/setState.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 setState({
-  ${1}: ${2}
+	${1}: ${2}
 });
 ]]></content>
     <tabTrigger>sst</tabTrigger>

--- a/snippets/shouldComponentUpdate.sublime-snippet
+++ b/snippets/shouldComponentUpdate.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 shouldComponentUpdate: function(nextProps, nextState) {
-  ${1}
+	${1}
 },
 ]]></content>
     <tabTrigger>scu</tabTrigger>


### PR DESCRIPTION
The snippets are currently using two spaces, which enforces this practice no matter which settings the user has. I have changed this to tabs in accordance with [Sublime's help text](http://sublimetext.info/docs/en/extensibility/snippets.html):

> When writing a snippet that contains indentation, always use tabs. The tabs will be transformed into spaces when the snippet is inserted if the option translateTabsToSpaces is set to true.

This way, the user's preferences are respected.
