### PR TITLE
Add snippet for React.addons.classSet

### DIFF
--- a/snippets/classSet.sublime-snippet
+++ b/snippets/classSet.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 var cx = React.addons.classSet;
 ]]></content>
-    <tabTrigger>cx</tabTrigger>
+    <tabTrigger>cs</tabTrigger>
     <scope>source.js</scope>
     <description>React: var cx = React.addons.classSet;</description>
 </snippet>

--- a/snippets/cx.sublime-snippet
+++ b/snippets/cx.sublime-snippet
@@ -1,0 +1,10 @@
+<snippet>
+    <content><![CDATA[
+cx({
+	$1: $2
+});
+]]></content>
+    <tabTrigger>cx</tabTrigger>
+    <scope>source.js</scope>
+    <description>React: cx({ ... })</description>
+</snippet>


### PR DESCRIPTION
A snippet for assigning `cx` as outlined [here](http://facebook.github.io/react/docs/class-name-manipulation.html)

I have a local snippet for this and I find it really useful.
