### PR TITLE
Update component skeleton to use require('react');

### DIFF
--- a/snippets/react_component.sublime-snippet
+++ b/snippets/react_component.sublime-snippet
@@ -3,7 +3,7 @@
  * @jsx React.DOM
  */
 
-var React = require('React');
+var React = require('react');
 
 var ${1} = React.createClass({
 


### PR DESCRIPTION
Not sure, which use case is covered by original skeleton, but if you're in node/browserify environment, you're probably using [react on npm](https://www.npmjs.org/package/react) package and it's starting with lowercase.
