### PR TITLE
Add "Wrap in a component" snippet

### DIFF
--- a/snippets/js/wrap.sublime-snippet
+++ b/snippets/js/wrap.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+    <content><![CDATA[${SELECTION/( +).*/$1/}<${1:Component}>
+$0${SELECTION/([ \t]+)([^\n]+)/\t$1$2/g}
+${SELECTION/( +).*/$1/}</${1/([^ ]+).*/$1/}>]]></content>
+    <scope>source.js</scope>
+    <description>Wrap in a component</description>
+</snippet>


### PR DESCRIPTION
Built-in Sublime snippet
![](http://recordit.co/vz1HLWd8mN.gif)

React-specific modification
![](http://recordit.co/QePA08T98E.gif)

To assign a hotkey for the snippet, go to Preferences - Key Bindings - User

```
[
  {
    "keys": ["ctrl+shift+w"],
    "command": "insert_snippet",
    "args": { "name": "Packages/sublime-react/wrap.sublime-snippet" }
  }
]
```
