### PR TITLE
Allow inline block comments in Coffee JSX

### DIFF
--- a/syntax/jsx-coffee/CoffeeScript (JSX).JSON-tmLanguage
+++ b/syntax/jsx-coffee/CoffeeScript (JSX).JSON-tmLanguage
@@ -298,7 +298,7 @@
       }
     },
     "begin": "(?<!#)###(?!#)",
-    "end": "###(?:[ \\t]*\\n)",
+    "end": "###",
     "name": "comment.block.coffee",
     "patterns": [{
       "name": "storage.type.annotation.coffeescript",


### PR DESCRIPTION
Currently, comments are tough to build in Coffee-JSX:

``` coffee
{### comment here ###}
```

breaks syntax highlighting for the rest of the file

This fixes that, as the capture after the closing `###` isn't required for the highlighting to work properly.
