### PR TITLE
Update react_component.sublime-snippet

### DIFF
--- a/snippets/js/react_component.sublime-snippet
+++ b/snippets/js/react_component.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 var React = require('react');
 
-var ${1} = React.createClass({
+var ${1:${TM_FILENAME/(.?\w*)(?:\.\w+)*$/$1/g}} = React.createClass({
 
 	render: function() {
 		return (
@@ -12,7 +12,7 @@ var ${1} = React.createClass({
 
 });
 
-module.exports = ${1};
+module.exports = ${1:${TM_FILENAME/(.?\w*)(?:\.\w+)*$/$1/g}};
 ]]></content>
     <tabTrigger>rcc</tabTrigger>
     <scope>source.js</scope>


### PR DESCRIPTION
This PR adds a default value for $1 placeholder - it takes $TM_FILENAME	(Name of the file being edited, including extension.) and tries to strip off one or multiple extensions and assume that is the component name. 
This will support flow when you create a component in a separate file, like `MyComp.js.jsx` and run `rcc`.
Tested it on:
Stable channel, build 3065