### PR TITLE
Add displayName, line at end of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sublime-react
 
-Snippets for ReactJS. This package used to provide JSX syntax highlighting and has been DEPRECATED in favor of [babel/babel-sublime](https://github.com/babel/babel-sublime).
+Snippets for ReactJS. This package used to provide JSX syntax highlighting and has been DEPRECATED in favor of babel/babel-sublime.
 
 ![alt tag](https://raw.github.com/jgebhardt/sublime-react/master/docs/img/sr-rcc-out.gif)
 

--- a/snippets/js/react_component.sublime-snippet
+++ b/snippets/js/react_component.sublime-snippet
@@ -4,7 +4,7 @@ var React = require('react');
 
 var ${1:${TM_FILENAME/(.?\w*)(?:\.\w+)*$/$1/g}} = React.createClass({
 
-	render: function() {
+  render: function() {
 		return (
 			${0:<div />}
 		);
@@ -13,6 +13,7 @@ var ${1:${TM_FILENAME/(.?\w*)(?:\.\w+)*$/$1/g}} = React.createClass({
 });
 
 module.exports = ${1:${TM_FILENAME/(.?\w*)(?:\.\w+)*$/$1/g}};
+
 ]]></content>
     <tabTrigger>rcc</tabTrigger>
     <scope>source.js</scope>


### PR DESCRIPTION
displayName is useful for debugging and required by [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) and [standard](https://github.com/feross/standard) which uses it. I figured this is something worth having. JSX [will infer it](https://facebook.github.io/react/docs/jsx-in-depth.html#the-transform) automatically from the variable assignment if undefined, but this allows you to notice and change it if needed. 

Standard also requires a newline at the end of file.
